### PR TITLE
Fixes #14: Add option to override the default alert priority

### DIFF
--- a/flask_opsgenie/__init__.py
+++ b/flask_opsgenie/__init__.py
@@ -151,9 +151,9 @@ class FlaskOpsgenie(object):
         return response
 
     def raise_exception_alert(self, alert_type:AlertType = None, exception=None, func_name:str=None,
-                              extra_props: Dict[str,str] = {}):
+                              extra_props: Dict[str,str] = {}, alert_priority: str = ''):
         raise_opsgenie_alert(alert_type=alert_type, exception=exception, func_name=func_name, opsgenie_alert_params=self.opsgenie_params_util(),
-                             extra_props=extra_props)
+                             extra_props=extra_props, alert_priority=alert_priority)
 
     def raise_gevent_exception_alert(self, greenlet):
         try:

--- a/flask_opsgenie/opsgenie.py
+++ b/flask_opsgenie/opsgenie.py
@@ -4,7 +4,7 @@ from requests import HTTPError
 import traceback
 from typing import Any, Dict, Optional
 from flask import request
-from flask_opsgenie.entities import AlertType, OpsgenieAlertParams
+from flask_opsgenie.entities import AlertType, OpsgenieAlertParams, AlertPriority
 
 logger = logging.getLogger(__name__)
 
@@ -237,7 +237,14 @@ def raise_manual_alert(exception=None, func_name:str=None, opsgenie_alert_params
 def raise_opsgenie_alert(alert_type:AlertType = None, alert_status_code:Optional[int] = None, \
                          alert_status_class:Optional[str] = None, elapsed_time:Optional[int] = None,
                          exception=None, opsgenie_alert_params:OpsgenieAlertParams=None, response_status_code: int=None,
-                         func_name:str=None, extra_props: Dict[str,str] = {}):
+                         func_name:str=None, extra_props: Dict[str,str] = {}, alert_priority: str = ''):
+
+    # handle overrides
+    if alert_priority != '':
+        try:
+            opsgenie_alert_params.alert_priority = AlertPriority(alert_priority)
+        except ValueError as e:
+            logger.exception(e)
 
     if alert_type == AlertType.STATUS_ALERT:
         if alert_status_code:


### PR DESCRIPTION
The raise_exception_alert will now accept an additional param
like ```alert_priority``` which will override the default
priority coming from the initial config. However this will
not be working for gevent exception since we dont controll it
from the user side.